### PR TITLE
Switch to pytest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ classifiers = [
     'Topic :: Scientific/Engineering :: Visualization',
     'Topic :: Multimedia :: Graphics :: Presentation']
 
-tests_require = ['unittest_expander']
+tests_require = ['pytest']
 
 setup(name="tdvisu",
       version=version,

--- a/tdvisu/visualization.py
+++ b/tdvisu/visualization.py
@@ -160,9 +160,11 @@ class Visualization:
     @staticmethod
     def solution_node(
             solution_table,
-            toplabel='',
-            bottomlabel='',
-            transpose=False, linesmax=1000, columnsmax=50) -> str:
+            toplabel: str = '',
+            bottomlabel: str = '',
+            transpose: bool = False,
+            linesmax: int = 1000,
+            columnsmax: int = 50) -> str:
         """Fill the node from the 2D 'solution_table' (columnbased!).
         Optionally add a line above and/or below the table.
 
@@ -428,7 +430,7 @@ class Visualization:
 
         # Prepare supporting graph timeline
 
-        _timeline : List[Optional[object]] = []
+        _timeline: List[Optional[object]] = []
         for step in self.timeline:
             if len(step) < 2:
                 _timeline.append(None)

--- a/test/test_bag_creation.py
+++ b/test/test_bag_creation.py
@@ -37,7 +37,7 @@ SOLUTIONTABLEFLOAT = [["id", 0.1], ["v1", 1.],
                       ["nSol", 0.1]]
 
 
-class TestSolutionNode(unittest.TestCase):
+class TestSolutionNode:
     """Testing different solution_node capabilities."""
 
     def test_solutionnode_empty(self):

--- a/test/test_bag_creation.py
+++ b/test/test_bag_creation.py
@@ -20,77 +20,57 @@ Copyright (C) 2020  Martin Röbke
 
 """
 
-
+from pytest import param, mark
 from tdvisu.visualization import Visualization
 
 
 SOLUTIONTABLE1 = [["id", "0"], ["v1", "1"],
-                  ["v2", "2"], ["v3", "4"],
-                  ["nSol", "0"]]
+                  ["v2", "2"], ["v3", "4"], ["nSol", "0"]]
 
-SOLUTIONTABLEINT = [["id", 0], ["v1", 1],
-                    ["v2", 2], ["v3", 4],
-                    ["nSol", 0]]
+SOLUTIONTABLEINT = [["id", 0], ["v1", 1], ["v2", 2], ["v3", 4], ["nSol", 0]]
 
-SOLUTIONTABLEFLOAT = [["id", 0.1], ["v1", 1.],
-                      ["v2", 2.2222], ["v3", 4.4],
+SOLUTIONTABLEFLOAT = [["id", 0.1], ["v1", 1.], ["v2", 2.2222], ["v3", 4.4],
                       ["nSol", 0.1]]
 
+SOLUTIONHEADER = [["id"], ["v1"], ["v2"], ["v3"], ["nSol"]]
 
-class TestSolutionNode:
+
+parameters_sol = [
+    param({'solution_table': tuple()},
+          "{empty}", id='with empty args'),
+    param({'solution_table': tuple(), 'toplabel': 'top'},
+          "{top|empty}", id='with one toplabel'),
+    param({'solution_table': tuple(), 'bottomlabel': 'bottom'},
+          "{empty|bottom}", id='with one bottomlabel'),
+    param({'solution_table': SOLUTIONTABLE1, 'toplabel': 'top',
+           'bottomlabel': 'bottom', 'transpose': True},
+          "{top|{{id|v1|v2|v3|nSol}|{0|1|2|4|0}}|bottom}",
+          id='with both labels and transposed'),
+    param({'solution_table': SOLUTIONTABLE1},
+          "{{{id|0}|{v1|1}|{v2|2}|{v3|4}|{nSol|0}}}",
+          id='not transposed no label'),
+    param({'solution_table': SOLUTIONTABLE1, 'toplabel': 'top',
+           'bottomlabel': 'bottom'},
+          "{top|{{id|0}|{v1|1}|{v2|2}|{v3|4}|{nSol|0}}|bottom}",
+          id='not transposed plus labels'),
+    param({'solution_table': SOLUTIONHEADER},
+          "{{{id}|{v1}|{v2}|{v3}|{nSol}}}",
+          id='only header'),
+    param({'solution_table': SOLUTIONHEADER, 'toplabel': 'top',
+           'bottomlabel': 'bottom'},
+          "{top|{{id}|{v1}|{v2}|{v3}|{nSol}}|bottom}",
+          id='only header plus labels'),
+    param({'solution_table': SOLUTIONTABLEINT},
+          "{{{id|0}|{v1|1}|{v2|2}|{v3|4}|{nSol|0}}}",
+          id='conversion of ints in table'),
+    param({'solution_table': SOLUTIONTABLEFLOAT},
+          "{{{id|0.1}|{v1|1.0}|{v2|2.2222}|{v3|4.4}|{nSol|0.1}}}",
+          id='conversion of floats'), ]
+
+
+@mark.parametrize("arguments,expected", parameters_sol)
+def test_solutionnode(arguments, expected):
     """Testing different solution_node capabilities."""
 
-    @staticmethod
-    def test_solutionnode_empty():
-        """Solution node with empty args."""
-        result = Visualization.solution_node([])
-        assert result == "{empty}"
-
-    @staticmethod
-    def test_solutionnode_empty_toplabel():
-        """Solution node with one toplabel."""
-        result = Visualization.solution_node([], "top")
-        assert result == "{top|empty}"
-
-    @staticmethod
-    def test_solutionnode_empty_bottomlabel():
-        """Solution node with one bottomlabel."""
-        result = Visualization.solution_node([], bottomlabel="bottom")
-        assert result == "{empty|bottom}"
-
-    @staticmethod
-    def test_solutionnode_transpose():
-        """Solution node with both labels and transposed SOLUTIONTABLE1."""
-        result = Visualization.solution_node(
-            SOLUTIONTABLE1, "top", "bottom", transpose=True)
-        assert result == "{top|{{id|v1|v2|v3|nSol}|{0|1|2|4|0}}|bottom}"
-
-    @staticmethod
-    def test_solutionnode_fulltable():
-        """Solution node with SOLUTIONTABLE1 not transposed."""
-        result = Visualization.solution_node(SOLUTIONTABLE1)
-        assert result == "{{{id|0}|{v1|1}|{v2|2}|{v3|4}|{nSol|0}}}"
-
-        result = Visualization.solution_node(SOLUTIONTABLE1, "top", "bottom")
-        assert result == "{top|{{id|0}|{v1|1}|{v2|2}|{v3|4}|{nSol|0}}|bottom}"
-
-    @staticmethod
-    def test_solutionnode_only_header():
-        """Solution node with only one line."""
-        solution_table = [["id"], ["v1"],
-                          ["v2"], ["v3"],
-                          ["nSol"]]
-        result = Visualization.solution_node(solution_table)
-        assert result == "{{{id}|{v1}|{v2}|{v3}|{nSol}}}"
-
-        result = Visualization.solution_node(solution_table, "top", "bottom")
-        assert result == "{top|{{id}|{v1}|{v2}|{v3}|{nSol}}|bottom}"
-
-    @staticmethod
-    def test_solutionnode_header_numbers():
-        """Solution node with different number formats."""
-        result = Visualization.solution_node(SOLUTIONTABLEINT)
-        assert result == "{{{id|0}|{v1|1}|{v2|2}|{v3|4}|{nSol|0}}}"
-
-        result = Visualization.solution_node(SOLUTIONTABLEFLOAT)
-        assert result == "{{{id|0.1}|{v1|1.0}|{v2|2.2222}|{v3|4.4}|{nSol|0.1}}}"
+    result = Visualization.solution_node(**arguments)
+    assert result == expected

--- a/test/test_bag_creation.py
+++ b/test/test_bag_creation.py
@@ -20,7 +20,7 @@ Copyright (C) 2020  Martin Röbke
 
 """
 
-import unittest
+
 from tdvisu.visualization import Visualization
 
 
@@ -40,57 +40,57 @@ SOLUTIONTABLEFLOAT = [["id", 0.1], ["v1", 1.],
 class TestSolutionNode:
     """Testing different solution_node capabilities."""
 
-    def test_solutionnode_empty(self):
+    @staticmethod
+    def test_solutionnode_empty():
         """Solution node with empty args."""
         result = Visualization.solution_node([])
-        self.assertEqual(result, "{empty}")
+        assert result == "{empty}"
 
-    def test_solutionnode_empty_toplabel(self):
+    @staticmethod
+    def test_solutionnode_empty_toplabel():
         """Solution node with one toplabel."""
         result = Visualization.solution_node([], "top")
-        self.assertEqual(result, "{top|empty}")
+        assert result == "{top|empty}"
 
-    def test_solutionnode_empty_bottomlabel(self):
+    @staticmethod
+    def test_solutionnode_empty_bottomlabel():
         """Solution node with one bottomlabel."""
         result = Visualization.solution_node([], bottomlabel="bottom")
-        self.assertEqual(result, "{empty|bottom}")
+        assert result == "{empty|bottom}"
 
-    def test_solutionnode_transpose(self):
+    @staticmethod
+    def test_solutionnode_transpose():
         """Solution node with both labels and transposed SOLUTIONTABLE1."""
         result = Visualization.solution_node(
             SOLUTIONTABLE1, "top", "bottom", transpose=True)
-        self.assertEqual(
-            result, "{top|{{id|v1|v2|v3|nSol}|{0|1|2|4|0}}|bottom}")
+        assert result == "{top|{{id|v1|v2|v3|nSol}|{0|1|2|4|0}}|bottom}"
 
-    def test_solutionnode_fulltable(self):
+    @staticmethod
+    def test_solutionnode_fulltable():
         """Solution node with SOLUTIONTABLE1 not transposed."""
         result = Visualization.solution_node(SOLUTIONTABLE1)
-        self.assertEqual(result, "{{{id|0}|{v1|1}|{v2|2}|{v3|4}|{nSol|0}}}")
+        assert result == "{{{id|0}|{v1|1}|{v2|2}|{v3|4}|{nSol|0}}}"
 
         result = Visualization.solution_node(SOLUTIONTABLE1, "top", "bottom")
-        self.assertEqual(
-            result, "{top|{{id|0}|{v1|1}|{v2|2}|{v3|4}|{nSol|0}}|bottom}")
+        assert result == "{top|{{id|0}|{v1|1}|{v2|2}|{v3|4}|{nSol|0}}|bottom}"
 
-    def test_solutionnode_only_header(self):
+    @staticmethod
+    def test_solutionnode_only_header():
         """Solution node with only one line."""
-        solutionTable = [["id"], ["v1"],
-                         ["v2"], ["v3"],
-                         ["nSol"]]
-        result = Visualization.solution_node(solutionTable)
-        self.assertEqual(result, "{{{id}|{v1}|{v2}|{v3}|{nSol}}}")
+        solution_table = [["id"], ["v1"],
+                          ["v2"], ["v3"],
+                          ["nSol"]]
+        result = Visualization.solution_node(solution_table)
+        assert result == "{{{id}|{v1}|{v2}|{v3}|{nSol}}}"
 
-        result = Visualization.solution_node(solutionTable, "top", "bottom")
-        self.assertEqual(result, "{top|{{id}|{v1}|{v2}|{v3}|{nSol}}|bottom}")
+        result = Visualization.solution_node(solution_table, "top", "bottom")
+        assert result == "{top|{{id}|{v1}|{v2}|{v3}|{nSol}}|bottom}"
 
-    def test_solutionnode_header_numbers(self):
+    @staticmethod
+    def test_solutionnode_header_numbers():
         """Solution node with different number formats."""
         result = Visualization.solution_node(SOLUTIONTABLEINT)
-        self.assertEqual(result, "{{{id|0}|{v1|1}|{v2|2}|{v3|4}|{nSol|0}}}")
+        assert result == "{{{id|0}|{v1|1}|{v2|2}|{v3|4}|{nSol|0}}}"
 
         result = Visualization.solution_node(SOLUTIONTABLEFLOAT)
-        self.assertEqual(
-            result, "{{{id|0.1}|{v1|1.0}|{v2|2.2222}|{v3|4.4}|{nSol|0.1}}}")
-
-
-if __name__ == '__main__':
-    unittest.main()
+        assert result == "{{{id|0.1}|{v1|1.0}|{v2|2.2222}|{v3|4.4}|{nSol|0.1}}}"

--- a/test/test_svgjoin.py
+++ b/test/test_svgjoin.py
@@ -21,12 +21,11 @@ Copyright (C) 2020  Martin Röbke
 
 """
 
-import unittest
+from pytest import param, mark
 from os.path import dirname, join
 from random import randint
 from typing import Generator
 from benedict import benedict
-from unittest_expander import expand, foreach, param
 
 from tdvisu.svgjoin import f_transform, append_svg, gen_arg
 
@@ -58,64 +57,62 @@ def rand_smaller(number):
     return last_random
 
 
-@expand
-class TestNewHeight(unittest.TestCase):
+class TestNewHeight:
     """Test the transform method in svgjoin"""
 
     parameters_default = [
         param({'h_one_': BASE, 'h_two_': BASE},
-              expected={'vertical_snd': 0.0, 'vertical_fst': 0.0, 'combine_height': BASE,
-                        'scale2': 1}).label('Only heights (same)'),
+              {'vertical_snd': 0.0, 'vertical_fst': 0.0, 'combine_height': BASE,
+                        'scale2': 1}, id='Only heights (same)'),
         param({'h_one_': BASE, 'h_two_': 2 * BASE},
-              expected={'vertical_snd': 0.0, 'vertical_fst': 0.0, 'combine_height': 2 * BASE,
-                        'scale2': 1}).label('Only heights (larger)'),
+              {'vertical_snd': 0.0, 'vertical_fst': 0.0, 'combine_height': 2 * BASE,
+                        'scale2': 1}, id='Only heights (larger)'),
         param({'h_one_': BASE, 'h_two_': 0.5 * BASE},
-              expected={'vertical_snd': 0.0, 'vertical_fst': 0.0, 'combine_height': BASE,
-                        'scale2': 1}).label('Only heights (smaller)'),
+              {'vertical_snd': 0.0, 'vertical_fst': 0.0, 'combine_height': BASE,
+                        'scale2': 1}, id='Only heights (smaller)'),
         param({'h_one_': BASE, 'h_two_': BASE, 'v_bottom': None},
-              expected={'vertical_snd': 0.0, 'vertical_fst': 0.0, 'combine_height': BASE,
-                        'scale2': 1}).label('Default v_bottom'),
+              {'vertical_snd': 0.0, 'vertical_fst': 0.0, 'combine_height': BASE,
+                        'scale2': 1}, id='Default v_bottom'),
         param({'h_one_': BASE, 'h_two_': BASE, 'v_bottom': None, 'v_top': None},
-              expected={'vertical_snd': 0.0, 'vertical_fst': 0.0, 'combine_height': BASE,
-                        'scale2': 1}).label('Default v_bottom&v_top'),
+              {'vertical_snd': 0.0, 'vertical_fst': 0.0, 'combine_height': BASE,
+                        'scale2': 1}, id='Default v_bottom&v_top'),
         param({'h_one_': BASE, 'h_two_': BASE, 'scale2': 1},
-              expected={'vertical_snd': 0.0, 'vertical_fst': 0.0, 'combine_height': BASE,
-                        'scale2': 1}).label('Default scale2')]
+              {'vertical_snd': 0.0, 'vertical_fst': 0.0, 'combine_height': BASE,
+                        'scale2': 1}, id='Default scale2')]
 
     parameters_moving = [
         param({'h_one_': BASE, 'h_two_': BASE, 'v_bottom': 1, 'v_top': 0},
-              expected={'vertical_snd': 0.0, 'vertical_fst': 0.0, 'combine_height': BASE,
-                        'scale2': 1}).label('static'),
+              {'vertical_snd': 0.0, 'vertical_fst': 0.0, 'combine_height': BASE,
+                        'scale2': 1}, id='static'),
         param({'h_one_': BASE, 'h_two_': BASE, 'v_bottom': 0, 'v_top': 1},
-              expected={'vertical_snd': 0.0, 'vertical_fst': 0.0, 'combine_height': BASE,
-                        'scale2': 1}).label("switched bottom and top -> "
+              {'vertical_snd': 0.0, 'vertical_fst': 0.0, 'combine_height': BASE,
+                        'scale2': 1}, id="switched bottom and top -> "
                                             "should switch automatically!"),
         param({'h_one_': BASE, 'h_two_': rand_smaller(BASE), 'v_bottom': 1, 'v_top': 0},
-              expected={'vertical_snd': BASE - last_random, 'vertical_fst': 0.0,
+              {'vertical_snd': BASE - last_random, 'vertical_fst': 0.0,
                         'combine_height': BASE, 'scale2': BASE / last_random}
-              ).label('scale up to BASE'),
+              , id='scale up to BASE'),
         param({'h_one_': BASE, 'h_two_': rand_larger(BASE), 'v_bottom': 1, 'v_top': 0},
-              expected={'vertical_snd': BASE - last_random, 'vertical_fst': 0.0,
+              {'vertical_snd': BASE - last_random, 'vertical_fst': 0.0,
                         'combine_height': BASE, 'scale2': BASE / last_random}
-              ).label('scale down to BASE'),
+              , id='scale down to BASE'),
     ]
 
-    @foreach(parameters_default)
-    def test_parameters_default(self, kargs, expected):
+    @mark.parametrize("test_input,expected", parameters_default)
+    def test_parameters_default(self, test_input, expected):
         """Test that the default parameters from f_transform work as expected."""
-        if isinstance(kargs, dict):
-            result = f_transform(**kargs)
-            self.assertEqual(result, expected)
+        result = f_transform(**test_input)
+        self.assertEqual(result, expected)
 
-    @foreach(parameters_moving)
-    def test_parameters_moving(self, kargs, expected):
+    @mark.parametrize("test_input,expected", parameters_moving)
+    def test_parameters_moving(self, test_input, expected):
         """Test that different parameters for f_transform work as expected."""
-        if isinstance(kargs, dict):
-            result = f_transform(**kargs)
-            self.assertEqual(result, expected)
+
+        result = f_transform(**test_input)
+        self.assertEqual(result, expected)
 
 
-class TestGenArg(unittest.TestCase):
+class TestGenArg:
     """Test the generator in svgjoin"""
 
     def test_none(self):
@@ -158,7 +155,7 @@ class TestGenArg(unittest.TestCase):
                              arg + [arg[-1] for _ in range(size - len(arg))])
 
 
-class TestAppendSvg(unittest.TestCase):
+class TestAppendSvg:
     """Test the append_svg method in svgjoin"""
 
     DIR = dirname(__file__)
@@ -257,18 +254,3 @@ class TestAppendSvg(unittest.TestCase):
                     self.assertEqual(
                         result, benedict.from_xml(expected.read()))
 
-
-if __name__ == '__main__':
-    import sys
-    VERBOSITY = 1  # increase for more output
-
-    def run_tests(*test_case_classes):
-        """Create a test suite for the testcases in 'test_case_classes'."""
-        suite = unittest.TestSuite(
-            unittest.TestLoader().loadTestsFromTestCase(cls)
-            for cls in test_case_classes)
-        unittest.TextTestRunner(
-            stream=sys.stdout,
-            verbosity=VERBOSITY).run(suite)
-    # run selected tests:
-    run_tests(TestNewHeight, TestAppendSvg)

--- a/test/test_svgjoin.py
+++ b/test/test_svgjoin.py
@@ -21,10 +21,10 @@ Copyright (C) 2020  Martin Röbke
 
 """
 
-from pytest import param, mark
 from os.path import dirname, join
 from random import randint
 from typing import Generator
+from pytest import param, mark
 from benedict import benedict
 
 from tdvisu.svgjoin import f_transform, append_svg, gen_arg
@@ -96,17 +96,16 @@ class TestNewHeight:
                'combine_height': BASE, 'scale2': BASE / last_random}, id='scale down to BASE'),
     ]
 
-    @mark.parametrize("test_input,expected", parameters_default)
-    def test_parameters_default(self, test_input, expected):
+    @mark.parametrize("arguments,expected", parameters_default)
+    def test_parameters_default(self, arguments, expected):
         """Test that the default parameters from f_transform work as expected."""
-        result = f_transform(**test_input)
+        result = f_transform(**arguments)
         assert result == expected
 
-    @mark.parametrize("test_input,expected", parameters_moving)
-    def test_parameters_moving(self, test_input, expected):
+    @mark.parametrize("arguments,expected", parameters_moving)
+    def test_parameters_moving(self, arguments, expected):
         """Test that different parameters for f_transform work as expected."""
-
-        result = f_transform(**test_input)
+        result = f_transform(**arguments)
         assert result == expected
 
 

--- a/test/test_svgjoin.py
+++ b/test/test_svgjoin.py
@@ -63,53 +63,51 @@ class TestNewHeight:
     parameters_default = [
         param({'h_one_': BASE, 'h_two_': BASE},
               {'vertical_snd': 0.0, 'vertical_fst': 0.0, 'combine_height': BASE,
-                        'scale2': 1}, id='Only heights (same)'),
+               'scale2': 1}, id='Only heights (same)'),
         param({'h_one_': BASE, 'h_two_': 2 * BASE},
               {'vertical_snd': 0.0, 'vertical_fst': 0.0, 'combine_height': 2 * BASE,
-                        'scale2': 1}, id='Only heights (larger)'),
+               'scale2': 1}, id='Only heights (larger)'),
         param({'h_one_': BASE, 'h_two_': 0.5 * BASE},
               {'vertical_snd': 0.0, 'vertical_fst': 0.0, 'combine_height': BASE,
-                        'scale2': 1}, id='Only heights (smaller)'),
+               'scale2': 1}, id='Only heights (smaller)'),
         param({'h_one_': BASE, 'h_two_': BASE, 'v_bottom': None},
               {'vertical_snd': 0.0, 'vertical_fst': 0.0, 'combine_height': BASE,
-                        'scale2': 1}, id='Default v_bottom'),
+               'scale2': 1}, id='Default v_bottom'),
         param({'h_one_': BASE, 'h_two_': BASE, 'v_bottom': None, 'v_top': None},
               {'vertical_snd': 0.0, 'vertical_fst': 0.0, 'combine_height': BASE,
-                        'scale2': 1}, id='Default v_bottom&v_top'),
+               'scale2': 1}, id='Default v_bottom&v_top'),
         param({'h_one_': BASE, 'h_two_': BASE, 'scale2': 1},
               {'vertical_snd': 0.0, 'vertical_fst': 0.0, 'combine_height': BASE,
-                        'scale2': 1}, id='Default scale2')]
+               'scale2': 1}, id='Default scale2')]
 
     parameters_moving = [
         param({'h_one_': BASE, 'h_two_': BASE, 'v_bottom': 1, 'v_top': 0},
               {'vertical_snd': 0.0, 'vertical_fst': 0.0, 'combine_height': BASE,
-                        'scale2': 1}, id='static'),
+               'scale2': 1}, id='static'),
         param({'h_one_': BASE, 'h_two_': BASE, 'v_bottom': 0, 'v_top': 1},
               {'vertical_snd': 0.0, 'vertical_fst': 0.0, 'combine_height': BASE,
-                        'scale2': 1}, id="switched bottom and top -> "
-                                            "should switch automatically!"),
+               'scale2': 1}, id="switched bottom and top -> "
+              "should switch automatically!"),
         param({'h_one_': BASE, 'h_two_': rand_smaller(BASE), 'v_bottom': 1, 'v_top': 0},
               {'vertical_snd': BASE - last_random, 'vertical_fst': 0.0,
-                        'combine_height': BASE, 'scale2': BASE / last_random}
-              , id='scale up to BASE'),
+               'combine_height': BASE, 'scale2': BASE / last_random}, id='scale up to BASE'),
         param({'h_one_': BASE, 'h_two_': rand_larger(BASE), 'v_bottom': 1, 'v_top': 0},
               {'vertical_snd': BASE - last_random, 'vertical_fst': 0.0,
-                        'combine_height': BASE, 'scale2': BASE / last_random}
-              , id='scale down to BASE'),
+               'combine_height': BASE, 'scale2': BASE / last_random}, id='scale down to BASE'),
     ]
 
     @mark.parametrize("test_input,expected", parameters_default)
     def test_parameters_default(self, test_input, expected):
         """Test that the default parameters from f_transform work as expected."""
         result = f_transform(**test_input)
-        self.assertEqual(result, expected)
+        assert result == expected
 
     @mark.parametrize("test_input,expected", parameters_moving)
     def test_parameters_moving(self, test_input, expected):
         """Test that different parameters for f_transform work as expected."""
 
         result = f_transform(**test_input)
-        self.assertEqual(result, expected)
+        assert result == expected
 
 
 class TestGenArg:
@@ -118,41 +116,38 @@ class TestGenArg:
     def test_none(self):
         """Should accept None as argument"""
         gen = gen_arg(None)
-        self.assertIsInstance(gen, Generator)
-        self.assertListEqual([next(gen) for _ in range(3)],
-                             [None for _ in range(3)])
+        assert isinstance(gen, Generator)
+        assert [next(gen) for _ in range(3)] == [None for _ in range(3)]
 
     def test_int(self):
         """One integer in generator"""
         arg = randint(1, 100)
         gen = gen_arg(arg)
         size = randint(5, 20)
-        self.assertListEqual([next(gen) for _ in range(size)],
-                             [arg for _ in range(size)])
+        assert[next(gen) for _ in range(size)] == [arg for _ in range(size)]
 
     def test_string(self):
         """Should yield the string itself"""
         arg = "Hello Test"
         gen = gen_arg(arg)
         size = randint(5, 20)
-        self.assertListEqual([next(gen) for _ in range(size)],
-                             [arg for _ in range(size)])
+        assert [next(gen) for _ in range(size)] == [arg for _ in range(size)]
 
     def test_none_in_list(self):
         """Should accept None as element in list"""
         arg = [None, randint(1, 1e4), None]
         gen = gen_arg(arg)
         size = randint(5, 20)
-        self.assertListEqual([next(gen) for _ in range(size)],
-                             arg + [arg[-1] for _ in range(size - len(arg))])
+        assert ([next(gen) for _ in range(size)] ==
+                arg + [arg[-1] for _ in range(size - len(arg))])
 
     def test_nested(self):
         """Should only return elements from the first level"""
         arg = [[1, 2], "String", None, [[[1]]]]
         gen = gen_arg(arg)
         size = randint(5, 20)
-        self.assertListEqual([next(gen) for _ in range(size)],
-                             arg + [arg[-1] for _ in range(size - len(arg))])
+        assert ([next(gen) for _ in range(size)] ==
+                arg + [arg[-1] for _ in range(size - len(arg))])
 
 
 class TestAppendSvg:
@@ -174,8 +169,7 @@ class TestAppendSvg:
                 # with open('result_simple_join.svg', 'w') as file:
                 #     result.to_xml(output=file, pretty=True)
                 with open(join(self.DIR, 'result_simple_join.svg'), 'r') as expected:
-                    self.assertEqual(
-                        result, benedict.from_xml(expected.read()))
+                    assert result == benedict.from_xml(expected.read())
 
     def test_simple_join_switched(self):
         """Test the reverse order - compare to result."""
@@ -189,8 +183,7 @@ class TestAppendSvg:
                 # with open('result_simple_join_switched.svg', 'w') as file:
                 #     result.to_xml(output=file, pretty=True)
                 with open(join(self.DIR, 'result_simple_join_switched.svg'), 'r') as expected:
-                    self.assertEqual(
-                        result, benedict.from_xml(expected.read()))
+                    assert result == benedict.from_xml(expected.read())
 
     def test_simple_join_padding(self):
         """Test the horizontal padding - compare to result."""
@@ -204,8 +197,7 @@ class TestAppendSvg:
                 # with open('result_simple_join_padding.svg', 'w') as file:
                 #     result.to_xml(output=file, pretty=True)
                 with open(join(self.DIR, 'result_simple_join_padding.svg'), 'r') as expected:
-                    self.assertEqual(
-                        result, benedict.from_xml(expected.read()))
+                    assert result == benedict.from_xml(expected.read())
 
     def test_scaleddown_join(self):
         """Scale larger to same size - compare to result."""
@@ -219,8 +211,7 @@ class TestAppendSvg:
                 # with open('result_scaled_join.svg', 'w') as file:
                 #     result.to_xml(output=file, pretty=True)
                 with open(join(self.DIR, 'result_scaled_join.svg'), 'r') as expected:
-                    self.assertEqual(
-                        result, benedict.from_xml(expected.read()))
+                    assert result == benedict.from_xml(expected.read())
 
     def test_centered_smaller_join(self):
         """Center the smaller image - compare to result."""
@@ -235,8 +226,7 @@ class TestAppendSvg:
                 # with open('result_centered_join.svg', 'w') as file:
                 #     result.to_xml(output=file, pretty=True)
                 with open(join(self.DIR, 'result_centered_join.svg'), 'r') as expected:
-                    self.assertEqual(
-                        result, benedict.from_xml(expected.read()))
+                    assert result == benedict.from_xml(expected.read())
 
     def test_centered_larger_join(self):
         """Center the smaller image - compare to result."""
@@ -251,6 +241,4 @@ class TestAppendSvg:
                 # with open('result_centered_join2.svg', 'w') as file:
                 #     result.to_xml(output=file, pretty=True)
                 with open(join(self.DIR, 'result_centered_join2.svg'), 'r') as expected:
-                    self.assertEqual(
-                        result, benedict.from_xml(expected.read()))
-
+                    assert result == benedict.from_xml(expected.read())

--- a/test/test_version.py
+++ b/test/test_version.py
@@ -21,39 +21,35 @@ Copyright (C) 2020  Martin Röbke
 """
 from datetime import date
 import re
-import unittest
+from pytest import fail
 from tdvisu.version import __date__, __version__ as version
 
 
-class TestVersion(unittest.TestCase):
-    """Testing fields in version."""
-
-    def test_semantic_version(self):
-        """Test the version-format with https://semver.org/spec/v2.0.0.html."""
-        self.assertIsInstance(version, str)
-        regex = (
-            r"^(?P<major>0|[1-9]\d*)\."
-            r"(?P<minor>0|[1-9]\d*)\."
-            r"(?P<patch>0|[1-9]\d*)"
-            r"(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
-            r"(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))"
-            r"?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$")
-        result = re.fullmatch(regex, version)
-        msg = f"The version {version} does not adhere to semantic versioning!"
-        self.assertIsNotNone(result, msg)
-
-    def test_date(self):
-        """The date should be 'YYYY-MM-DD' isoformat to be fully portable."""
-        self.assertIsInstance(__date__, str)
-        # Is it an existing date?
-        try:
-            date.fromisoformat(__date__)
-        except ValueError as err:
-            msg = f"""The date {__date__} is not in the format YYYY-MM-DD!
-                    ValueError: {err}
-                    Today would be: '{date.today().isoformat()}'"""
-            self.fail(msg)
+def test_semantic_version():
+    """Test the version-format with https://semver.org/spec/v2.0.0.html."""
+    assert isinstance(version, str)
+    regex = (
+        r"^(?P<major>0|[1-9]\d*)\."
+        r"(?P<minor>0|[1-9]\d*)\."
+        r"(?P<patch>0|[1-9]\d*)"
+        r"(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)"
+        r"(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))"
+        r"?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$")
+    result = re.fullmatch(regex, version)
+    if result is None:
+        fail(
+            f"The version {version} does not adhere to semantic versioning!",
+            pytrace=False)
 
 
-if __name__ == '__main__':
-    unittest.main()
+def test_date():
+    """The date should be 'YYYY-MM-DD' isoformat to be fully portable."""
+    assert isinstance(__date__, str)
+    # Is it an existing date?
+    try:
+        date.fromisoformat(__date__)
+    except ValueError as err:
+        msg = f"""The date {__date__} is not in the format YYYY-MM-DD!
+                ValueError: {err}
+                Today would be: '{date.today().isoformat()}'"""
+        fail(msg, pytrace=False)


### PR DESCRIPTION
(tdvisu) PS C:\Users\Martin\Documents\GitHub\tdvisu> pytest . -v                                                                                                                                     ====================== test session starts 
======================= platform win32 -- Python 3.8.3, pytest-5.4.2, py-1.8.1, pluggy-0.13.1 -- c:\users\martin\.conda\envs\tdvisu\python.exe                                                                               cachedir: .pytest_cache                                                                                                                                                                              rootdir: C:\Users\Martin\Documents\GitHub\tdvisu                                                                                                                                                     collected 33 items                                                                                                                                                                                                                                                                                                                                                                                        test/test_bag_creation.py::test_solutionnode[with empty args] PASSED                                                                                                                          [  3%] test/test_bag_creation.py::test_solutionnode[with one toplabel] PASSED                                                                                                                        [  6%] test/test_bag_creation.py::test_solutionnode[with one bottomlabel] PASSED                                                                                                                     [  9%] test/test_bag_creation.py::test_solutionnode[with both labels and transposed] PASSED                                                                                                          [ 12%] test/test_bag_creation.py::test_solutionnode[not transposed no label] PASSED                                                                                                                  [ 15%] test/test_bag_creation.py::test_solutionnode[not transposed plus labels] PASSED                                                                                                               [ 18%] test/test_bag_creation.py::test_solutionnode[only header] PASSED                                                                                                                              [ 21%] test/test_bag_creation.py::test_solutionnode[only header plus labels] PASSED                                                                                                                  [ 24%] test/test_bag_creation.py::test_solutionnode[conversion of ints in table] PASSED                                                                                                              [ 27%] test/test_bag_creation.py::test_solutionnode[conversion of floats] PASSED                                                                                                                     [ 30%] test/test_svgjoin.py::TestNewHeight::test_parameters_default[Only heights (same)] PASSED                                                                                                      [ 33%] test/test_svgjoin.py::TestNewHeight::test_parameters_default[Only heights (larger)] PASSED                                                                                                    [ 36%] test/test_svgjoin.py::TestNewHeight::test_parameters_default[Only heights (smaller)] PASSED                                                                                                   [ 39%] test/test_svgjoin.py::TestNewHeight::test_parameters_default[Default v_bottom] PASSED                                                                                                         [ 42%] test/test_svgjoin.py::TestNewHeight::test_parameters_default[Default v_bottom&v_top] PASSED                                                                                                   [ 45%] test/test_svgjoin.py::TestNewHeight::test_parameters_default[Default scale2] PASSED                                                                                                           [ 48%] test/test_svgjoin.py::TestNewHeight::test_parameters_moving[static] PASSED                                                                                                                    [ 51%] test/test_svgjoin.py::TestNewHeight::test_parameters_moving[switched bottom and top -> should switch automatically!] PASSED                                                                   [ 54%] test/test_svgjoin.py::TestNewHeight::test_parameters_moving[scale up to BASE] PASSED                                                                                                          [ 57%] test/test_svgjoin.py::TestNewHeight::test_parameters_moving[scale down to BASE] PASSED                                                                                                        [ 60%] test/test_svgjoin.py::TestGenArg::test_none PASSED                                                                                                                                            [ 63%] test/test_svgjoin.py::TestGenArg::test_int PASSED                                                                                                                                             [ 66%] test/test_svgjoin.py::TestGenArg::test_string PASSED                                                                                                                                          [ 69%] test/test_svgjoin.py::TestGenArg::test_none_in_list PASSED                                                                                                                                    [ 72%] test/test_svgjoin.py::TestGenArg::test_nested PASSED                                                                                                                                          [ 75%] test/test_svgjoin.py::TestAppendSvg::test_simple_join PASSED                                                                                                                                  [ 78%] test/test_svgjoin.py::TestAppendSvg::test_simple_join_switched PASSED                                                                                                                         [ 81%] test/test_svgjoin.py::TestAppendSvg::test_simple_join_padding PASSED                                                                                                                          [ 84%] test/test_svgjoin.py::TestAppendSvg::test_scaleddown_join PASSED                                                                                                                              [ 87%] test/test_svgjoin.py::TestAppendSvg::test_centered_smaller_join PASSED                                                                                                                        [ 90%] test/test_svgjoin.py::TestAppendSvg::test_centered_larger_join PASSED                                                                                                                         [ 93%] test/test_version.py::test_semantic_version PASSED                                                                                                                                            [ 96%] test/test_version.py::test_date PASSED                                                                                                                                                        [100%]                                                                                                                                                                                                      ========================================================================================= warnings summary ========================================================================================= c:\users\martin\.conda\envs\tdvisu\lib\site-packages\win32\lib\pywintypes.py:2                                                                                                                         c:\users\martin\.conda\envs\tdvisu\lib\site-packages\win32\lib\pywintypes.py:2: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses 